### PR TITLE
Makes trailing slashes tolerable

### DIFF
--- a/app.js
+++ b/app.js
@@ -163,7 +163,7 @@ MockREST.prototype.getData = function(path, method, req) {
         response,
         returnObj = routes;
 
-    pathChunks.shift();
+    pathChunks = pathChunks.filter((chunk) => !!chunk);
 
     if (pathChunks.length < 1) {
         return 'Please specify a valid RESTful request. Examples\r\n' +

--- a/test/test.js
+++ b/test/test.js
@@ -15,6 +15,11 @@ describe('Base connection', function() {
             .expect(200, done)
     });
 
+    it('responds with a 200 if the existing route has a trailing slash', function(done) {
+        api.get('/products/')
+            .expect(200, done)
+    });
+
     it('responds correctly when getting an item', function(done) {
        api.get('/products/1')
            .expect(200, '{"id":1,"obj":"carrot","packages":{"single":{"id":9,"price":0.9},"kilo":{"id":10,"price":0.5}}}', done);


### PR DESCRIPTION
Allows for `/stores` and `/stores/` to both respond with the contents of the collection.